### PR TITLE
Fix thumbnails for remote images in search

### DIFF
--- a/assets/search-ui.js
+++ b/assets/search-ui.js
@@ -15,7 +15,12 @@ function excerptedString(str) {
 
 function getThumbnail(item, url) {
   if (item.thumbnail) {
-    return `<img class='sq-thumb-sm' src='${url}${item.thumbnail}'/>&nbsp;&nbsp;&nbsp;`
+    if (item.thumbnail.startsWith('https')) {
+		  return `<img class='sq-thumb-sm' src='${item.thumbnail}'/>&nbsp;&nbsp;&nbsp;`
+	  }
+	else {
+		return `<img class='sq-thumb-sm' src='${url}${item.thumbnail}'/>&nbsp;&nbsp;&nbsp;`
+	  }
   }
   else {
     return `<img class='sq-thumb-sm' src='${url}${DEFAULT}'/>&nbsp;&nbsp;&nbsp;`


### PR DESCRIPTION
This should fix the issue with thumbnails not showing up in the search interface.